### PR TITLE
chore: Use rtm.connect instead of rtm.start

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,7 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(channel_for(target), strings)
+        api.send_messages(target.room, strings)
       end
 
       def set_topic(target, topic)
@@ -59,14 +59,6 @@ module Lita
       private
 
       attr_reader :rtm_connection
-
-      def channel_for(target)
-        if target.private_message?
-          rtm_connection.im_for(target.user.id)
-        else
-          target.room
-        end
-      end
 
       def channel_roster(room_id, api)
         response = api.channels_info room_id

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -69,15 +69,16 @@ module Lita
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
 
-        def rtm_start
-          response_data = call_api("rtm.start")
+        def rtm_connect
+          response_data = call_api("rtm.connect")
+
+          raise RuntimeError, response_data["error"] if response_data["ok"] != true
 
           TeamData.new(
-            SlackIM.from_data_array(response_data["ims"]),
+            response_data["team"]["id"],
+            response_data["team"]["name"],
+            response_data["team"]["domain"],
             SlackUser.from_data(response_data["self"]),
-            SlackUser.from_data_array(response_data["users"]),
-            SlackChannel.from_data_array(response_data["channels"]) +
-              SlackChannel.from_data_array(response_data["groups"]),
             response_data["url"],
           )
         end

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -17,23 +17,15 @@ module Lita
 
         class << self
           def build(robot, config)
-            new(robot, config, API.new(config).rtm_start)
+            new(robot, config, API.new(config).rtm_connect)
           end
         end
 
         def initialize(robot, config, team_data)
           @robot = robot
           @config = config
-          @im_mapping = IMMapping.new(API.new(config), team_data.ims)
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
-
-          UserCreator.create_users(team_data.users, robot, robot_id)
-          RoomCreator.create_rooms(team_data.channels, robot)
-        end
-
-        def im_for(user_id)
-          im_mapping.im_for(user_id)
         end
 
         def run(queue = nil, options = {})

--- a/lib/lita/adapters/slack/team_data.rb
+++ b/lib/lita/adapters/slack/team_data.rb
@@ -2,7 +2,7 @@ module Lita
   module Adapters
     # @api private
     class Slack < Adapter
-      TeamData = Struct.new(:ims, :self, :users, :channels, :websocket_url)
+      TeamData = Struct.new(:id, :name, :domain, :self, :websocket_url)
     end
   end
 end


### PR DESCRIPTION
修正 slack api 語法

Ref: [Starting November 30 2021, new apps will not be able to connect using the rtm.start API calls](https://api.slack.com/changelog/2021-10-rtm-start-to-stop)