### PR TITLE
chore: disable tls verify

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -103,7 +103,7 @@ module Lita
         end
 
         def websocket_options
-          options = { ping: 10 }
+          options = { ping: 10, tls: { verify_peer: false } }
           options[:proxy] = { :origin => config.proxy } if config.proxy
           options
         end


### PR DESCRIPTION
slack 的憑證目前有問題，Lita container 起不來

先採用 workround 的方法，把 tls 的檢查關掉

Ref: https://github.com/getoutreach/lita-slack-test-upgrade-faye/commit/d88bddf0485f6d6791e6aff9bd256d629e3ac937